### PR TITLE
fix README.md code examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,12 +77,12 @@ struct ExampleWidget {
 Which expands to exactly...
 
 ```rust
-impl reclutch::WidgetChildren<<Self as reclutch::Widget>::Aux> for ExampleWidget {
-    fn children(&self) -> Vec<&dyn reclutch::WidgetChildren<Self::Aux>> {
+impl reclutch::widget::WidgetChildren for ExampleWidget {
+    fn children(&self) -> Vec<&dyn reclutch::widget::WidgetChildren<Aux = Self::Aux>> {
         vec![&self.child]
     }
 
-    fn children_mut(&mut self) -> Vec<&mut dyn reclutch::WidgetChildren<Self::Aux>> {
+    fn children_mut(&mut self) -> Vec<&mut dyn reclutch::widget::WidgetChildren<Aux = Self::Aux>> {
         vec![&mut self.child]
     }
 }
@@ -116,7 +116,7 @@ struct VisualWidget {
 
 impl Widget for VisualWidget {
     // --snip--
-    
+
     fn update(&mut self, _aux: &mut ()) {
         if self.changed {
             self.command_group.repaint();

--- a/event/README.md
+++ b/event/README.md
@@ -42,12 +42,12 @@ Here's an example of it's usage outside a widget (with manual updating);
 ```rust
 let mut event: RcEventQueue<i32> = RcEventQueue::new();
 
-event.push(10); // no listeners, so this event won't be received by anyone.
+event.emit_owned(10); // no listeners, so this event won't be received by anyone.
 
 let listener = event.listen();
 
-event.push(1);
-event.push(2);
+event.emit_owned(1);
+event.emit_owned(2);
 
 // here is how listeners respond to events.
 for num in listener.peek() {


### PR DESCRIPTION
The lastest merges (especially #13) broke the example codes in the README.md files. This PR fixes that.