### PR TITLE
update winit to v0.20.0-alpha5

### DIFF
--- a/event/Cargo.toml
+++ b/event/Cargo.toml
@@ -21,7 +21,7 @@ futures-core = { version = "0.3", optional = true }
 retain_mut = "0.1"
 slotmap = "0.4"
 # keep this in sync with the version listed in reclutch/Cargo.toml
-winit = { version = "0.20.0-alpha4", optional = true }
+winit = { version = "0.20.0-alpha5", optional = true }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/event/src/thirdparty.rs
+++ b/event/src/thirdparty.rs
@@ -234,14 +234,9 @@ impl<T> QueueInterfaceCommon for winit::event_loop::EventLoopProxy<T> {
 impl<T: Clone> Emitter for winit::event_loop::EventLoopProxy<T> {
     #[inline]
     fn emit<'a>(&self, event: Cow<'a, T>) -> EmitResult<'a, T> {
-        if self.send_event(event.clone().into_owned()).is_ok() {
-            EmitResult::Delivered
-        } else {
-            // sadly, EventLoopProxy::send_event doesn't give us the owned event back
-            // if it fails
-            // ref: https://github.com/rust-windowing/winit/issues/1292
-            EmitResult::Undelivered(event)
-        }
+        self.send_event(event.into_owned())
+            .map_err(|winit::event_loop::EventLoopClosed(x)| Cow::Owned(x))
+            .into()
     }
 }
 


### PR DESCRIPTION
This PR fixes a suboptimal implementation of the `Emitter` trait for winit-`EventLoopProxy`, which required that rust-windowing/winit#1292 is fixed (which is fixed in `winit v0.20.0-alpha5`).