### PR TITLE
Fix clippy warnings

### DIFF
--- a/core/src/display/mod.rs
+++ b/core/src/display/mod.rs
@@ -611,6 +611,7 @@ impl DisplayText {
     ///
     /// # Example
     /// ```rust
+    /// # extern crate reclutch_core as reclutch;
     /// use reclutch::display::DisplayText;
     ///
     /// let text = DisplayText::Simple("Hello, world!".to_string());
@@ -962,9 +963,7 @@ pub enum DisplayClip {
 impl DisplayClip {
     pub fn bounds(&self) -> Rect {
         match self {
-            DisplayClip::Rectangle { rect, .. } | DisplayClip::RoundRectangle { rect, .. } => {
-                (*rect)
-            }
+            DisplayClip::Rectangle { rect, .. } | DisplayClip::RoundRectangle { rect, .. } => *rect,
             DisplayClip::Ellipse { center, radii } => Rect::new(
                 (center.x - radii.x, center.y - radii.y).into(),
                 (radii.x * 2.0, radii.y * 2.0).into(),

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -48,12 +48,9 @@ fn impl_widget_macro(ast: &syn::DeriveInput) -> TokenStream {
     }) {
         let mut out = None;
         for token in attr.tokens.clone().into_iter() {
-            match token {
-                proc_macro2::TokenTree::Group(grp) => {
-                    out = Some(grp.stream());
-                    break;
-                }
-                _ => {}
+            if let proc_macro2::TokenTree::Group(grp) = token {
+                out = Some(grp.stream());
+                break;
             }
         }
 

--- a/event/src/cascade/mod.rs
+++ b/event/src/cascade/mod.rs
@@ -197,8 +197,8 @@ mod tests {
             s.spawn(move |_| run_worker(stop_rx, cascades));
             let sub = ev2.listen_and_subscribe();
             let sub2 = ev3.listen_and_subscribe();
-            ev1.emit_owned(2).to_result().unwrap();
-            ev1.emit_owned(1).to_result().unwrap();
+            ev1.emit_owned(2).into_result().unwrap();
+            ev1.emit_owned(1).into_result().unwrap();
             assert_eq!(sub.notifier.recv(), Ok(()));
             assert_eq!(sub.listener.peek(), &[1]);
             assert_eq!(sub2.notifier.recv(), Ok(()));
@@ -223,8 +223,8 @@ mod tests {
         );
         crossbeam_utils::thread::scope(move |s| {
             s.spawn(move |_| run_worker(stop_rx, cascades));
-            ev1_tx.emit_owned(2).to_result().unwrap();
-            ev1_tx.emit_owned(1).to_result().unwrap();
+            ev1_tx.emit_owned(2).into_result().unwrap();
+            ev1_tx.emit_owned(1).into_result().unwrap();
             assert_eq!(ev2_rx.recv(), Ok(1));
             assert_eq!(ev3_rx.recv(), Ok(2));
             std::mem::drop(stop_tx);
@@ -245,8 +245,8 @@ mod tests {
                     ev1_rx.push(ev2_tx, false, |i| i % 2 == 1).push(ev3_tx, false, |_| true).wrap(),
                 )
                 .unwrap();
-            ev1_tx.emit_owned(2).to_result().unwrap();
-            ev1_tx.emit_owned(1).to_result().unwrap();
+            ev1_tx.emit_owned(2).into_result().unwrap();
+            ev1_tx.emit_owned(1).into_result().unwrap();
             assert_eq!(ev2_rx.recv(), Ok(1));
             assert_eq!(ev3_rx.recv(), Ok(2));
         })
@@ -265,8 +265,8 @@ mod tests {
         );
         crossbeam_utils::thread::scope(move |s| {
             s.spawn(move |_| run_worker(stop_rx, cascades));
-            ev1_tx.emit_owned(2).to_result().unwrap();
-            ev1_tx.emit_owned(1).to_result().unwrap();
+            ev1_tx.emit_owned(2).into_result().unwrap();
+            ev1_tx.emit_owned(1).into_result().unwrap();
             assert_eq!(ev2_rx.recv(), Ok(1));
             assert_eq!(ev3_rx.recv(), Ok(true));
             std::mem::drop(stop_tx);
@@ -285,8 +285,8 @@ mod tests {
         crossbeam_utils::thread::scope(move |s| {
             let (_stop_tx, stop_rx) = chan::bounded(0);
             s.spawn(move |_| run_worker(stop_rx, cascades));
-            ev1_tx.emit_owned(2).to_result().unwrap();
-            ev1_tx.emit_owned(1).to_result().unwrap();
+            ev1_tx.emit_owned(2).into_result().unwrap();
+            ev1_tx.emit_owned(1).into_result().unwrap();
             std::mem::drop(ev1_tx);
             assert_eq!(ev2_rx.recv(), Ok(2));
             assert_eq!(ev2_rx.recv(), Ok(1));
@@ -307,8 +307,8 @@ mod tests {
         crossbeam_utils::thread::scope(move |s| {
             let (_stop_tx, stop_rx) = chan::bounded(0);
             s.spawn(move |_| run_worker(stop_rx, cascades));
-            ev1_tx.emit_owned(2).to_result().unwrap();
-            ev1_tx.emit_owned(1).to_result().unwrap();
+            ev1_tx.emit_owned(2).into_result().unwrap();
+            ev1_tx.emit_owned(1).into_result().unwrap();
             std::mem::drop(ev1_tx);
             assert_eq!(ev2_rx.recv(), Ok(2));
             assert_eq!(ev2_rx.recv(), Ok(1));

--- a/event/src/chans.rs
+++ b/event/src/chans.rs
@@ -352,7 +352,7 @@ mod tests {
     fn test_event_listener() {
         let event = Queue::new();
 
-        event.emit_owned(0i32).to_result().unwrap_err();
+        event.emit_owned(0i32).into_result().unwrap_err();
 
         let suls = event.listen_and_subscribe();
         let data = &[1, 2, 3];
@@ -364,7 +364,7 @@ mod tests {
         });
 
         for i in data.into_iter() {
-            event.emit_borrowed(i).to_result().unwrap();
+            event.emit_borrowed(i).into_result().unwrap();
         }
         h.join().unwrap();
     }
@@ -375,13 +375,13 @@ mod tests {
 
         let suls1 = event.listen_and_subscribe();
 
-        event.emit_owned(10).to_result().unwrap();
+        event.emit_owned(10).into_result().unwrap();
 
         assert!(!event.buffer_is_empty());
 
         let suls2 = event.listen_and_subscribe();
 
-        event.emit_owned(20).to_result().unwrap();
+        event.emit_owned(20).into_result().unwrap();
 
         let h1 = std::thread::spawn(move || {
             assert_eq!(suls1.notifier.recv(), Ok(()));
@@ -401,7 +401,7 @@ mod tests {
         assert!(event.buffer_is_empty());
 
         for _i in 0..10 {
-            event.emit_owned(30).to_result().unwrap();
+            event.emit_owned(30).into_result().unwrap();
         }
 
         h1.join().unwrap();
@@ -418,8 +418,8 @@ mod tests {
         let suls1 = event1.listen_and_subscribe();
         let suls2 = event2.listen_and_subscribe();
 
-        event1.emit_owned(20).to_result().unwrap();
-        event2.emit_owned(10).to_result().unwrap();
+        event1.emit_owned(20).into_result().unwrap();
+        event2.emit_owned(10).into_result().unwrap();
 
         chan::select! {
             recv(suls1.notifier) -> _msg => {

--- a/event/src/dchans.rs
+++ b/event/src/dchans.rs
@@ -157,9 +157,9 @@ mod tests {
             }
         });
 
-        event.emit_owned(1).to_result().unwrap();
-        event.emit_owned(2).to_result().unwrap();
-        event.emit_owned(3).to_result().unwrap();
+        event.emit_owned(1).into_result().unwrap();
+        event.emit_owned(2).into_result().unwrap();
+        event.emit_owned(3).into_result().unwrap();
         h.join().unwrap();
     }
 
@@ -170,12 +170,12 @@ mod tests {
         let (sender, subs1) = chan::unbounded();
         event.push(sender);
 
-        event.emit_owned(10i32).to_result().unwrap();
+        event.emit_owned(10i32).into_result().unwrap();
 
         let (sender, subs2) = chan::unbounded();
         event.push(sender);
 
-        event.emit_owned(20i32).to_result().unwrap();
+        event.emit_owned(20i32).into_result().unwrap();
 
         let h1 = std::thread::spawn(move || {
             assert_eq!(subs1.recv(), Ok(10i32));
@@ -192,7 +192,7 @@ mod tests {
         std::thread::sleep(Duration::from_millis(200));
 
         for _i in 0..10 {
-            event.emit_owned(30i32).to_result().unwrap();
+            event.emit_owned(30i32).into_result().unwrap();
         }
 
         h1.join().unwrap();
@@ -204,8 +204,8 @@ mod tests {
         let (event1, subs1) = chan::unbounded();
         let (event2, subs2) = chan::unbounded();
 
-        event1.emit_owned(20i32).to_result().unwrap();
-        event2.emit_owned(10i32).to_result().unwrap();
+        event1.emit_owned(20i32).into_result().unwrap();
+        event2.emit_owned(10i32).into_result().unwrap();
 
         chan::select! {
             recv(subs1) -> msg => {

--- a/event/src/intern.rs
+++ b/event/src/intern.rs
@@ -146,13 +146,13 @@ mod tests {
     fn test_event_listener() {
         let mut event = Queue::new();
 
-        event.emit_owned(0).to_result().unwrap_err();
+        event.emit_owned(0).into_result().unwrap_err();
 
         let listener = event.create_listener();
 
-        event.emit_owned(1).to_result().unwrap();
-        event.emit_owned(2).to_result().unwrap();
-        event.emit_owned(3).to_result().unwrap();
+        event.emit_owned(1).into_result().unwrap();
+        event.emit_owned(2).into_result().unwrap();
+        event.emit_owned(3).into_result().unwrap();
 
         event.pull_with(listener, |x| assert_eq!(x, &[1, 2, 3]));
 
@@ -165,13 +165,13 @@ mod tests {
 
         let listener_1 = event.create_listener();
 
-        event.emit_owned(10).to_result().unwrap();
+        event.emit_owned(10).into_result().unwrap();
 
         assert_eq!(event.events_len(), 1);
 
         let listener_2 = event.create_listener();
 
-        event.emit_owned(20).to_result().unwrap();
+        event.emit_owned(20).into_result().unwrap();
 
         event.pull_with(listener_1, |x| assert_eq!(x, &[10, 20]));
         event.pull_with(listener_2, |x| assert_eq!(x, &[20]));
@@ -181,7 +181,7 @@ mod tests {
         assert_eq!(event.events_len(), 0);
 
         for _i in 0..10 {
-            event.emit_owned(30).to_result().unwrap();
+            event.emit_owned(30).into_result().unwrap();
         }
 
         event.pull_with(listener_2, |x| assert_eq!(x, &[30; 10]));

--- a/event/src/nonrc.rs
+++ b/event/src/nonrc.rs
@@ -71,13 +71,13 @@ mod tests {
     fn test_event_listener() {
         let event = Queue::new();
 
-        event.emit_owned(0i32).to_result().unwrap_err();
+        event.emit_owned(0i32).into_result().unwrap_err();
 
         let listener = event.listen();
 
-        event.emit_owned(1i32).to_result().unwrap();
-        event.emit_owned(2i32).to_result().unwrap();
-        event.emit_owned(3i32).to_result().unwrap();
+        event.emit_owned(1i32).into_result().unwrap();
+        event.emit_owned(2i32).into_result().unwrap();
+        event.emit_owned(3i32).into_result().unwrap();
 
         assert_eq!(listener.peek(), &[1, 2, 3]);
 
@@ -90,13 +90,13 @@ mod tests {
 
         let listener_1 = event.listen();
 
-        event.emit_owned(10i32).to_result().unwrap();
+        event.emit_owned(10i32).into_result().unwrap();
 
         assert_eq!(event.borrow().events.len(), 1);
 
         let listener_2 = event.listen();
 
-        event.emit_owned(20i32).to_result().unwrap();
+        event.emit_owned(20i32).into_result().unwrap();
 
         assert_eq!(listener_1.peek(), &[10i32, 20i32]);
         assert_eq!(listener_2.peek(), &[20i32]);
@@ -106,7 +106,7 @@ mod tests {
         assert_eq!(event.borrow().events.len(), 0);
 
         for _i in 0..10 {
-            event.emit_owned(30i32).to_result().unwrap();
+            event.emit_owned(30i32).into_result().unwrap();
         }
 
         assert_eq!(listener_2.peek(), &[30i32; 10]);

--- a/event/src/nonts.rs
+++ b/event/src/nonts.rs
@@ -76,13 +76,13 @@ mod tests {
     fn test_event_listener() {
         let event = Queue::default();
 
-        event.emit_owned(0i32).to_result().unwrap_err();
+        event.emit_owned(0i32).into_result().unwrap_err();
 
         let listener = event.listen();
 
-        event.emit_owned(1i32).to_result().unwrap();
-        event.emit_owned(2i32).to_result().unwrap();
-        event.emit_owned(3i32).to_result().unwrap();
+        event.emit_owned(1i32).into_result().unwrap();
+        event.emit_owned(2i32).into_result().unwrap();
+        event.emit_owned(3i32).into_result().unwrap();
 
         assert_eq!(listener.peek(), &[1, 2, 3]);
 
@@ -95,13 +95,13 @@ mod tests {
 
         let listener_1 = event.listen();
 
-        event.emit_owned(10i32).to_result().unwrap();
+        event.emit_owned(10i32).into_result().unwrap();
 
         assert_eq!(event.borrow().events.len(), 1);
 
         let listener_2 = event.listen();
 
-        event.emit_owned(20i32).to_result().unwrap();
+        event.emit_owned(20i32).into_result().unwrap();
 
         assert_eq!(listener_1.peek(), &[10i32, 20i32]);
         assert_eq!(listener_2.peek(), &[20i32]);
@@ -111,7 +111,7 @@ mod tests {
         assert_eq!(event.borrow().events.len(), 0);
 
         for _i in 0..10 {
-            event.emit_owned(30i32).to_result().unwrap();
+            event.emit_owned(30i32).into_result().unwrap();
         }
 
         assert_eq!(listener_2.peek(), &[30i32; 10]);

--- a/event/src/streaming/direct.rs
+++ b/event/src/streaming/direct.rs
@@ -143,8 +143,8 @@ mod tests {
                 assert_eq!(tmp, [1, 2]);
             })
         });
-        eq.emit_owned(1u32).to_result().unwrap();
-        eq.emit_owned(2).to_result().unwrap();
+        eq.emit_owned(1u32).into_result().unwrap();
+        eq.emit_owned(2).into_result().unwrap();
         std::mem::drop(eq);
         h.join().unwrap();
     }

--- a/event/src/streaming/wrapper.rs
+++ b/event/src/streaming/wrapper.rs
@@ -143,8 +143,8 @@ mod tests {
                 assert_eq!(tmp, [1, 2]);
             })
         });
-        eq.emit_owned(1u32).to_result().unwrap();
-        eq.emit_owned(2).to_result().unwrap();
+        eq.emit_owned(1u32).into_result().unwrap();
+        eq.emit_owned(2).into_result().unwrap();
         std::mem::drop(eq);
         h.join().unwrap();
     }

--- a/event/src/thirdparty.rs
+++ b/event/src/thirdparty.rs
@@ -249,7 +249,7 @@ mod tests {
     fn test_event_listener() {
         let mut event = Vec::new();
 
-        event.emit_owned(0i32).to_result().unwrap_err();
+        event.emit_owned(0i32).into_result().unwrap_err();
 
         let (sender, receiver) = mpsc::channel();
         event.push(sender);
@@ -263,7 +263,7 @@ mod tests {
         });
 
         for i in data {
-            event.emit_borrowed(i).to_result().unwrap();
+            event.emit_borrowed(i).into_result().unwrap();
         }
         h.join().unwrap();
     }
@@ -275,12 +275,12 @@ mod tests {
         let (sender, subs1) = mpsc::channel();
         event.push(sender);
 
-        event.emit_owned(10i32).to_result().unwrap();
+        event.emit_owned(10i32).into_result().unwrap();
 
         let (sender, subs2) = mpsc::channel();
         event.push(sender);
 
-        event.emit_owned(20i32).to_result().unwrap();
+        event.emit_owned(20i32).into_result().unwrap();
 
         let h1 = std::thread::spawn(move || {
             assert_eq!(subs1.recv(), Ok(10i32));
@@ -297,7 +297,7 @@ mod tests {
         std::thread::sleep(Duration::from_millis(200));
 
         for _i in 0..10 {
-            event.emit_owned(30i32).to_result().unwrap();
+            event.emit_owned(30i32).into_result().unwrap();
         }
 
         h1.join().unwrap();

--- a/event/src/traits.rs
+++ b/event/src/traits.rs
@@ -30,7 +30,7 @@ impl<'a, T: Clone> EmitResult<'a, T> {
     }
 
     /// Converts this `EmitResult` into [`std::result::Result`].
-    pub fn to_result(self) -> Result<(), Cow<'a, T>> {
+    pub fn into_result(self) -> Result<(), Cow<'a, T>> {
         self.into()
     }
 }
@@ -44,9 +44,9 @@ impl<'a, T: Clone> From<Result<(), Cow<'a, T>>> for EmitResult<'a, T> {
     }
 }
 
-impl<'a, T: Clone> Into<Result<(), Cow<'a, T>>> for EmitResult<'a, T> {
-    fn into(self) -> Result<(), Cow<'a, T>> {
-        match self {
+impl<'a, T: Clone> From<EmitResult<'a, T>> for Result<(), Cow<'a, T>> {
+    fn from(emitres: EmitResult<'a, T>) -> Result<(), Cow<'a, T>> {
+        match emitres {
             EmitResult::Delivered => Result::Ok(()),
             EmitResult::Undelivered(x) => Result::Err(x),
         }

--- a/verbgraph/src/lib.rs
+++ b/verbgraph/src/lib.rs
@@ -31,10 +31,16 @@ pub struct UnboundQueueHandler<T, A: 'static, E: Event> {
     handlers: HashMap<&'static str, Rc<RefCell<dyn FnMut(&mut T, &mut A, E)>>>,
 }
 
+impl<T, A, E: Event> Default for UnboundQueueHandler<T, A, E> {
+    fn default() -> Self {
+        UnboundQueueHandler { handlers: Default::default() }
+    }
+}
+
 impl<T, A, E: Event> UnboundQueueHandler<T, A, E> {
     /// Creates a new, unbound queue handler.
     pub fn new() -> Self {
-        UnboundQueueHandler { handlers: HashMap::new() }
+        Default::default()
     }
 
     /// Adds a closure to be executed when an event of a specific key is matched.
@@ -148,7 +154,7 @@ impl<T: 'static, A: 'static> VerbGraph<T, A> {
 
     /// Invokes all the queue handlers in a linear fashion, however non-linear jumping between verb graphs is still supported.
     pub fn update_all(&mut self, obj: &mut T, additional: &mut A) {
-        for (_, handler_list) in &mut self.handlers {
+        for handler_list in self.handlers.values_mut() {
             VerbGraph::update_handlers(handler_list, obj, additional)
         }
     }


### PR DESCRIPTION
I reran `cargo fmt` and `cargo clippy` across the codebase and fixed most warnings (and a single failing test).