### PR TITLE
use 'as-any' crate

### DIFF
--- a/verbgraph/Cargo.toml
+++ b/verbgraph/Cargo.toml
@@ -9,5 +9,6 @@ homepage = "http://github.com/jazzfool/reclutch/tree/master/verbtree"
 repository = "http://github.com/jazzfool/reclutch"
 
 [dependencies]
-reclutch_core = { path = "../core" }
+as-any = "0.2"
 paste = "0.1"
+reclutch_core = { path = "../core" }


### PR DESCRIPTION
previous discussion: https://github.com/jazzfool/sinq/pull/2.

> I extracted the `AsAny` code from two crates and put it into the [`as-any`](https://crates.io/crates/as-any) crate. This PR switches from the "custom" implementation to use the crate instead. Maybe, we should upstream the `AnyQueueHandler` into the `reclutch` main crate.

> Perhaps downcasting could be constrained to types that implement `DynQueueHandler`, but that's up to you.